### PR TITLE
Eks calicni ce patch1

### DIFF
--- a/eks-calico-cni-calico-enterprise/aws/data.tf
+++ b/eks-calico-cni-calico-enterprise/aws/data.tf
@@ -1,11 +1,11 @@
 data "local_sensitive_file" "calico_enterprise_pull_secret" {
-  filename = "/Users/sabo/Source/demo/docker_cfg.json"
+  filename = "${var.calico_enterprise_pull_secret_path}"
 }
 
 data "local_sensitive_file" "calico_enterprise_manager_sslcert" {
-  filename = "/Users/sabo/Source/demo/STAR_tigera-solutions_io.crt"
+  filename = "${var.calico_enterprise_manager_sslcert_path}"
 }
 
 data "local_sensitive_file" "calico_enterprise_manager_sslkey" {
-  filename = "/Users/sabo/Source/demo/STAR_tigera-solutions_io.key"
+  filename = "${var.calico_enterprise_manager_sslkey_path}"
 }

--- a/eks-calico-cni-calico-enterprise/aws/data.tf
+++ b/eks-calico-cni-calico-enterprise/aws/data.tf
@@ -3,9 +3,13 @@ data "local_sensitive_file" "calico_enterprise_pull_secret" {
 }
 
 data "local_sensitive_file" "calico_enterprise_manager_sslcert" {
+  count = local.create_enterprise_manager_sslcerts ? 1 : 0
+
   filename = "${var.calico_enterprise_manager_sslcert_path}"
 }
 
 data "local_sensitive_file" "calico_enterprise_manager_sslkey" {
+  count = local.create_enterprise_manager_sslcerts ? 1 : 0
+
   filename = "${var.calico_enterprise_manager_sslkey_path}"
 }

--- a/eks-calico-cni-calico-enterprise/aws/helm_values/values-calico-enterprise.yaml
+++ b/eks-calico-cni-calico-enterprise/aws/helm_values/values-calico-enterprise.yaml
@@ -10,7 +10,7 @@ installation:
     ipam:
       type: Calico
   calicoNetwork:
-    bgp: Disabled
+    bgp: ${calico_network_bgp}
     ipPools:
     - cidr: ${pod_cidr}
       encapsulation: ${calico_encap}

--- a/eks-calico-cni-calico-enterprise/aws/main.tf
+++ b/eks-calico-cni-calico-enterprise/aws/main.tf
@@ -47,7 +47,8 @@ locals {
   key_name                           = var.ssh_keyname
   cluster_version                    = var.cluster_version
   pod_cidr                           = var.pod_cidr
-  calico_encap                       = "VXLAN"
+  calico_encap                       = var.calico_encap
+  calico_network_bgp                 = var.calico_network_bgp
   calico_enterprise_pull_secret      = data.local_sensitive_file.calico_enterprise_pull_secret.content
   create_enterprise_manager_sslcerts = var.create_enterprise_manager_sslcerts
   calico_enterprise_manager_sslcert  = data.local_sensitive_file.calico_enterprise_manager_sslcert.content

--- a/eks-calico-cni-calico-enterprise/aws/main.tf
+++ b/eks-calico-cni-calico-enterprise/aws/main.tf
@@ -51,8 +51,8 @@ locals {
   calico_network_bgp                 = var.calico_network_bgp
   calico_enterprise_pull_secret      = data.local_sensitive_file.calico_enterprise_pull_secret.content
   create_enterprise_manager_sslcerts = var.create_enterprise_manager_sslcerts
-  calico_enterprise_manager_sslcert  = data.local_sensitive_file.calico_enterprise_manager_sslcert.content
-  calico_enterprise_manager_sslkey   = data.local_sensitive_file.calico_enterprise_manager_sslkey.content
+  calico_enterprise_manager_sslcert  = one(data.local_sensitive_file.calico_enterprise_manager_sslcert[*].content)
+  calico_enterprise_manager_sslkey   = one(data.local_sensitive_file.calico_enterprise_manager_sslkey[*].content)
   calico_enterprise_helm_chart       = var.calico_enterprise_helm_chart
 
 
@@ -261,6 +261,7 @@ resource "helm_release" "calico_enterprise" {
     calico_enterprise_pull_secret = local.calico_enterprise_pull_secret
     pod_cidr                      = "${local.pod_cidr}"
     calico_encap                  = "${local.calico_encap}"
+    calico_network_bgp            = "${local.calico_network_bgp}"
   })]
 
   depends_on = [

--- a/eks-calico-cni-calico-enterprise/aws/variables.tf
+++ b/eks-calico-cni-calico-enterprise/aws/variables.tf
@@ -40,6 +40,18 @@ variable "cluster_service_ipv4_cidr" {
   default     = "10.9.0.0/16"
 }
 
+variable "calico_encap" {
+  description = "Calico network overlay type"
+  type        = string
+  default     = "VXLAN"
+}
+
+variable "calico_network_bgp" {
+  description = "Calico network BGP"
+  type        = string
+  default     = "Disabled"
+}
+
 variable "cluster_version" {
   description = "Kubernetes version for this cluster"
   type        = string
@@ -74,4 +86,22 @@ variable "create_enterprise_manager_sslcerts" {
   description = "Determines whether to create tigera-manager ssl certificates"
   type        = bool
   default     = false
+}
+
+variable "calico_enterprise_pull_secret_path" {
+  description = "Path to a local file that contains Calico Enterprise pull secret"
+  type        = string
+  default     = "/Users/Shared/docker_cfg.json"
+}
+
+variable "calico_enterprise_manager_sslcert_path" {
+  description = "Path to a local file that represents Calico Enterprise manager SSL cert (file can be empty but has to exist)"
+  type        = string
+  default     = "/Users/Shared/STAR_tigera-solutions_io.crt"
+}
+
+variable "calico_enterprise_manager_sslkey_path" {
+  description = "Path to a local file that represents Calico Enterprise manager SSL cert key (file can be empty but has to exist)"
+  type        = string
+  default     = "/Users/Shared/STAR_tigera-solutions_io.key"
 }


### PR DESCRIPTION
### Change log
- added variables
  - calico_encap - parametrizes network encapsulation value
  - calico_network_bgp - allows to enable or disable Calico BGP speaker, e.g. when VXLAN or IPIP encap is used
  - calico_enterprise_pull_secret_path - allows specifying path to the pull secret file
  - calico_enterprise_manager_sslcert_path - allows specifying path to the CE manager SSL cert
  - calico_enterprise_manager_sslkey_path - allows specifying path to the CE manager SSL cert key
- updated helm_values to use new vars
- updated data.tf and main.tf to use new vars and used `one()` function to allow dummy paths for SSL certs